### PR TITLE
Secure cookie policy changes

### DIFF
--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
@@ -89,6 +89,11 @@ namespace gpconnect_appointment_checker.Configuration.Infrastructure
                     AllowCachingResponses = false
                 });
             });
+
+            app.UseForwardedHeaders(new ForwardedHeadersOptions()
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedProto
+            });
         }
 
         private static void AddResponseHeaders(HttpContext context)

--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
@@ -89,11 +89,6 @@ namespace gpconnect_appointment_checker.Configuration.Infrastructure
                     AllowCachingResponses = false
                 });
             });
-
-            app.UseForwardedHeaders(new ForwardedHeadersOptions()
-            {
-                ForwardedHeaders = ForwardedHeaders.XForwardedProto
-            });
         }
 
         private static void AddResponseHeaders(HttpContext context)

--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ public static class ServiceCollectionExtensions
             s.Cookie.MaxAge = TimeSpan.FromMinutes(15);
             s.Cookie.HttpOnly = true;
             s.Cookie.IsEssential = true;
-            s.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            s.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
         });
 
         services.Configure<CookiePolicyOptions>(options =>


### PR DESCRIPTION
Attempted to use `Always` for the `SecureCookiePolicy` config however when we did so, the end user application would periodically crash as it was unable to make a request to the back end. Attempting to change the policy to `SameAsRequest` to remedy the issue.