### PR TITLE
Secure policy changes

### DIFF
--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
@@ -89,6 +89,11 @@ namespace gpconnect_appointment_checker.Configuration.Infrastructure
                     AllowCachingResponses = false
                 });
             });
+
+            app.UseForwardedHeaders(new ForwardedHeadersOptions()
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedProto
+            });
         }
 
         private static void AddResponseHeaders(HttpContext context)

--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
@@ -89,11 +89,6 @@ namespace gpconnect_appointment_checker.Configuration.Infrastructure
                     AllowCachingResponses = false
                 });
             });
-
-            app.UseForwardedHeaders(new ForwardedHeadersOptions()
-            {
-                ForwardedHeaders = ForwardedHeaders.XForwardedProto
-            });
         }
 
         private static void AddResponseHeaders(HttpContext context)

--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/Authentication/AuthenticationExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/Authentication/AuthenticationExtensions.cs
@@ -36,7 +36,7 @@ namespace gpconnect_appointment_checker.Configuration.Infrastructure.Authenticat
                 options.Events.OnValidatePrincipal = PrincipalValidator.ValidateAsync;
                 options.Cookie.Name = ".GpConnectAppointmentChecker.AuthenticationCookie";
                 options.Cookie.SameSite = SameSiteMode.None;
-                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
             })
             .AddOpenIdConnect(
                 _singleSignOnConfig.ChallengeScheme,

--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ public static class ServiceCollectionExtensions
         {
             options.ConsentCookie.Name = ".GpConnectAppointmentChecker.ConsentCookie";
             options.CheckConsentNeeded = context => true;
-            options.ConsentCookie.SecurePolicy = CookieSecurePolicy.Always;
+            options.ConsentCookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
             options.MinimumSameSitePolicy = SameSiteMode.Strict;
         });
 
@@ -113,7 +113,7 @@ public static class ServiceCollectionExtensions
         { 
             options.SuppressXFrameOptionsHeader = true;
             options.Cookie.HttpOnly = true;
-            options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
             options.Cookie.SameSite = SameSiteMode.Strict;
         });
 

--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ public static class ServiceCollectionExtensions
             s.Cookie.MaxAge = TimeSpan.FromMinutes(15);
             s.Cookie.HttpOnly = true;
             s.Cookie.IsEssential = true;
-            s.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            s.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
         });
 
         services.Configure<CookiePolicyOptions>(options =>


### PR DESCRIPTION
Found three further instances of the `SecureCookiePolicy` set to `Always`. Amended to `SameAsRequest` to avoid the end user application from crashing on AWS