### PR TITLE
API Fixes

### DIFF
--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ApplicationBuilderExtensions.cs
@@ -54,7 +54,7 @@ namespace gpconnect_appointment_checker.Configuration.Infrastructure
             app.Use(async (context, next) =>
             {
                 context.Session.SetString("SessionKey", "Session");
-                await next();
+                await next(context);
             });
             
             app.Use(async (context, next) =>


### PR DESCRIPTION
Added `context` to the `Next()` call in the session middleware config. The context is amended as part of the pipeline so needs to be passed directly to the next step