### PR TITLE
Secure cookie policy changes

### DIFF
--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
@@ -26,14 +26,14 @@ public static class ServiceCollectionExtensions
             s.Cookie.MaxAge = TimeSpan.FromMinutes(15);
             s.Cookie.HttpOnly = true;
             s.Cookie.IsEssential = true;
-            s.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            s.Cookie.SecurePolicy = CookieSecurePolicy.None;
         });
 
         services.Configure<CookiePolicyOptions>(options =>
         {
             options.ConsentCookie.Name = ".GpConnectAppointmentChecker.ConsentCookie";
             options.CheckConsentNeeded = context => true;
-            options.ConsentCookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+            options.ConsentCookie.SecurePolicy = CookieSecurePolicy.None;
             options.MinimumSameSitePolicy = SameSiteMode.Lax;
         });
 
@@ -113,7 +113,7 @@ public static class ServiceCollectionExtensions
         { 
             options.SuppressXFrameOptionsHeader = true;
             options.Cookie.HttpOnly = true;
-            options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.None;
             options.Cookie.SameSite = SameSiteMode.Lax;
         });
 

--- a/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Core/Configuration/Infrastructure/ServiceCollectionExtensions.cs
@@ -26,15 +26,15 @@ public static class ServiceCollectionExtensions
             s.Cookie.MaxAge = TimeSpan.FromMinutes(15);
             s.Cookie.HttpOnly = true;
             s.Cookie.IsEssential = true;
-            s.Cookie.SecurePolicy = CookieSecurePolicy.None;
+            s.Cookie.SecurePolicy = CookieSecurePolicy.Always;
         });
 
         services.Configure<CookiePolicyOptions>(options =>
         {
             options.ConsentCookie.Name = ".GpConnectAppointmentChecker.ConsentCookie";
             options.CheckConsentNeeded = context => true;
-            options.ConsentCookie.SecurePolicy = CookieSecurePolicy.None;
-            options.MinimumSameSitePolicy = SameSiteMode.Lax;
+            options.ConsentCookie.SecurePolicy = CookieSecurePolicy.Always;
+            options.MinimumSameSitePolicy = SameSiteMode.None;
         });
 
         services.Configure<FormOptions>(x => x.ValueCountLimit = 100000);
@@ -113,8 +113,8 @@ public static class ServiceCollectionExtensions
         { 
             options.SuppressXFrameOptionsHeader = true;
             options.Cookie.HttpOnly = true;
-            options.Cookie.SecurePolicy = CookieSecurePolicy.None;
-            options.Cookie.SameSite = SameSiteMode.Lax;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            options.Cookie.SameSite = SameSiteMode.None;
         });
 
         services


### PR DESCRIPTION
Reverted the secure cookie policies back to before the PEN test changes were made to bring the dev env back online