### PR TITLE
GCS-223 add org type select item for N/A

### DIFF
--- a/modules/end-user/src/gpconnect-appointment-checker/Pages/Private/Search.cshtml.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Pages/Private/Search.cshtml.cs
@@ -279,7 +279,11 @@ namespace gpconnect_appointment_checker.Pages
                 Text = ot.OrganisationTypeDescription,
                 Value = ot.OrganisationTypeCode
             }).ToList();
-            options.Insert(0, new SelectListItem());
+            options.Insert(0, new SelectListItem()
+            {
+                Text = "N/A",
+                Value = string.Empty
+            });
             return options;
         }
     }


### PR DESCRIPTION
- Add a default value of 'N/A' with value of empty string, which will be passed as null to API as does now, but gives better UX of N/A rather than no display text in dropdown. 

Ticket:https://nhsd-jira.digital.nhs.uk/browse/GCS-223

<img width="1047" alt="image" src="https://github.com/user-attachments/assets/3e6027a6-f0d7-4ed7-9043-6cd55cf6292d" />
