### PR TITLE
GCS-298 add UK date time for when results retrieved

### DIFF
--- a/modules/end-user/src/EndUserTests/SearchPageHelperTests.cs
+++ b/modules/end-user/src/EndUserTests/SearchPageHelperTests.cs
@@ -1,0 +1,117 @@
+using Xunit;
+using NSubstitute; // NSubstitute namespace
+using System;
+using Microsoft.Extensions.Time.Testing; // For FakeTimeProvider
+using FluentAssertions;
+using gpconnect_appointment_checker.Helpers;
+using gpconnect_appointment_checker.Helpers.Constants;
+using gpconnect_appointment_checker.Helpers.Extensions;
+
+// Make sure ITimeZoneProvider is in a namespace accessible here
+// using gpconnect_appointment_checker.Helpers.Time; // Example namespace
+
+public class SearchPageHelperTests
+{
+    [Theory]
+    [InlineData(2025, 5, 29, 14, 30, "Europe/London", "29 May 15:30", true, "BST (UTC+1) period")] // BST
+    [InlineData(2025, 1, 15, 14, 30, "Europe/London", "15 Jan 14:30", false, "GMT (UTC+0) period")] // GMT
+    [InlineData(2025, 5, 29, 14, 30, "America/New_York", "29 May 10:30", false, "Another timezone (EDT, UTC-4)")]
+    public void BuildSearchTimeCountString_HandlesTimeZonesCorrectly_WithNSubstitute(
+        int year, int month, int day, int hour, int minute,
+        string timeZoneId, string expectedTimePart, bool expectIsDst, string testDescription)
+    {
+        // Arrange
+        var fakeTimeProvider = new FakeTimeProvider();
+        var subTimeZoneProvider = Substitute.For<ITimeZoneProvider>();
+
+        var utcInputTime = new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero);
+        fakeTimeProvider.SetUtcNow(utcInputTime);
+
+        var realTimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        subTimeZoneProvider.FindSystemTimeZoneById(timeZoneId).Returns(realTimeZoneInfo);
+
+        subTimeZoneProvider
+            .ConvertTime(Arg.Any<DateTimeOffset>(), Arg.Any<TimeZoneInfo>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                // Get the actual DateTimeOffset passed to ConvertTime
+                var inputDto = ci.Arg<DateTimeOffset>();
+                // Get the actual TimeZoneInfo passed to ConvertTime
+                var destTz = ci.Arg<TimeZoneInfo>();
+
+                // Simulate the conversion based on the expected behavior for Europe/London
+                if (destTz.Id == "Europe/London")
+                {
+                    if (expectIsDst) // If it should be BST (UTC+1)
+                        return inputDto.ToOffset(TimeSpan.FromHours(1));
+                    else // If it should be GMT (UTC+0)
+                        return inputDto.ToOffset(TimeSpan.FromHours(0));
+                }
+
+                // For other time zones, you'd implement their specific conversion logic here
+                // For "America/New_York", EDT is UTC-4.
+                if (destTz.Id == "America/New_York")
+                {
+                    // For simplicity, hardcode the offset for the test date.
+                    // In a real scenario, you might have a more sophisticated fake for DST.
+                    return inputDto.ToOffset(TimeSpan.FromHours(-4)); // EDT is UTC-4
+                }
+
+                throw new InvalidOperationException($"Unexpected timezone ID for mock: {destTz.Id}");
+            });
+
+        const int count = 2; // Fixed count for simplicity in these tests
+
+        // Act
+        // Pass the NSubstitute substitute for ITimeZoneProvider
+        var result = SearchPageHelpers.BuildSearchTimeCountString(count, fakeTimeProvider, subTimeZoneProvider);
+
+        // Assert
+        var expectedSearchAtDate = string.Format(SearchConstants.SearchAtDate, expectedTimePart);
+        var expectedCountString = SearchConstants.SearchStatsCountText.Pluraliser(count);
+        var expected = $"{expectedSearchAtDate} - {expectedCountString}";
+
+        result.Should().Be(expected, $"because {testDescription}");
+
+        // Optional: Verify that the methods were called as expected
+        subTimeZoneProvider.Received(1).FindSystemTimeZoneById("Europe/London");
+        subTimeZoneProvider.Received(1).ConvertTime(utcInputTime, realTimeZoneInfo);
+    }
+
+    [Fact]
+    public void BuildSearchTimeCountString_PluraliserWorksForSingleCount_WithNSubstitute()
+    {
+        // Arrange
+        var fakeTimeProvider = new FakeTimeProvider();
+        var subTimeZoneProvider = Substitute.For<ITimeZoneProvider>();
+
+        var utcInputTime = new DateTimeOffset(2025, 5, 29, 14, 30, 0, TimeSpan.Zero); // BST period
+        fakeTimeProvider.SetUtcNow(utcInputTime);
+
+        // Mock FindSystemTimeZoneById
+        var realLondonTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
+        subTimeZoneProvider.FindSystemTimeZoneById("Europe/London").Returns(realLondonTimeZone);
+
+        // Mock ConvertTime to simulate BST conversion
+        subTimeZoneProvider
+            .ConvertTime(Arg.Any<DateTimeOffset>(), Arg.Any<TimeZoneInfo>())
+            .ReturnsForAnyArgs(utcInputTime.ToOffset(TimeSpan.FromHours(1))); // Simulate BST (UTC+1)
+
+        const int count = 1;
+
+        // Act
+        var result = SearchPageHelpers.BuildSearchTimeCountString(count, fakeTimeProvider, subTimeZoneProvider);
+
+        // Assert
+        var expectedTimePart = "29 May 15:30"; // 14:30 UTC + 1 hour BST
+        var expectedSearchAtDate = string.Format(SearchConstants.SearchAtDate, expectedTimePart);
+        var expectedCountString = SearchConstants.SearchStatsCountText.Pluraliser(count); // Should be "1 free slot"
+        var expected = $"{expectedSearchAtDate} - {expectedCountString}";
+
+        result.Should().Be(expected);
+
+        // Optional: Verify calls
+        subTimeZoneProvider.Received(1).FindSystemTimeZoneById("Europe/London");
+        subTimeZoneProvider.Received(1).ConvertTime(utcInputTime, realLondonTimeZone);
+    }
+}

--- a/modules/end-user/src/EndUserTests/SearchPageValidationTests.cs
+++ b/modules/end-user/src/EndUserTests/SearchPageValidationTests.cs
@@ -12,20 +12,20 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute; // Using NSubstitute instead of Moq
 
 namespace EndUserTests;
 
 public class SearchModelTests
 {
-    private readonly Mock<HttpContext> _mockHttpContext;
-    private readonly Mock<HttpRequest> _mockHttpRequest;
-    private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
-    private readonly Mock<IExportService> _mockExportService;
-    private readonly Mock<IApplicationService> _mockApplicationService;
-    private readonly Mock<IConfigurationService> _mockConfigurationService;
-    private readonly Mock<ISearchService> _mockSearchService;
-    private readonly Mock<ILogger<SearchModel>> _mockLogger;
+    private readonly HttpContext _mockHttpContext;
+    private readonly HttpRequest _mockHttpRequest;
+    private readonly IHttpContextAccessor _mockHttpContextAccessor;
+    private readonly IExportService _mockExportService;
+    private readonly IApplicationService _mockApplicationService;
+    private readonly IConfigurationService _mockConfigurationService;
+    private readonly ISearchService _mockSearchService;
+    private readonly ILogger<SearchModel> _mockLogger;
     private readonly SearchModel _searchModel;
 
     public SearchModelTests()
@@ -33,44 +33,43 @@ public class SearchModelTests
         var routeData = new RouteData();
         routeData.Values.Add("controller", "Search");
 
-        _mockHttpRequest = new Mock<HttpRequest>();
-        _mockHttpRequest.Setup(req => req.Scheme).Returns("https"); // Scheme like https
-        _mockHttpRequest.Setup(req => req.Host).Returns(new HostString("search")); // Set the host to 'search'
-        _mockHttpRequest.Setup(req => req.PathBase).Returns(new PathString("")); // Base path, can be empty
+        _mockHttpRequest = Substitute.For<HttpRequest>();
+        _mockHttpRequest.Scheme.Returns("https"); 
+        _mockHttpRequest.Host.Returns(new HostString("search")); 
+        _mockHttpRequest.PathBase.Returns(new PathString("")); 
 
-        _mockHttpContext = new Mock<HttpContext>();
-        _mockHttpContext.Setup(x => x.Request).Returns(_mockHttpRequest.Object);
-
+        _mockHttpContext = Substitute.For<HttpContext>();
+        _mockHttpContext.Request.Returns(_mockHttpRequest);
 
         var modelState = new ModelStateDictionary();
         var actionContext =
-            new ActionContext(_mockHttpContext.Object, routeData, new PageActionDescriptor(), modelState);
+            new ActionContext(_mockHttpContext, routeData, new PageActionDescriptor(), modelState);
 
         var modelMetadataProvider = new EmptyModelMetadataProvider();
         var viewData = new ViewDataDictionary(modelMetadataProvider, modelState);
-        var tempData = new TempDataDictionary(_mockHttpContext.Object, Mock.Of<ITempDataProvider>());
+        var tempData = new TempDataDictionary(_mockHttpContext, Substitute.For<ITempDataProvider>());
         var pageContext = new PageContext(actionContext)
         {
             ViewData = viewData,
-            HttpContext = _mockHttpContext.Object
+            HttpContext = _mockHttpContext
         };
 
-        // Mock other services
-        _mockExportService = new Mock<IExportService>();
-        _mockApplicationService = new Mock<IApplicationService>();
-        _mockConfigurationService = new Mock<IConfigurationService>();
-        _mockSearchService = new Mock<ISearchService>();
-        _mockLogger = new Mock<ILogger<SearchModel>>();
-        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        // Substitute other services
+        _mockExportService = Substitute.For<IExportService>();
+        _mockApplicationService = Substitute.For<IApplicationService>();
+        _mockConfigurationService = Substitute.For<IConfigurationService>();
+        _mockSearchService = Substitute.For<ISearchService>();
+        _mockLogger = Substitute.For<ILogger<SearchModel>>();
+        _mockHttpContextAccessor = Substitute.For<IHttpContextAccessor>();
 
         _searchModel = new SearchModel(
-            Mock.Of<IOptions<GeneralConfig>>(),
-            _mockHttpContextAccessor.Object,
-            _mockLogger.Object,
-            _mockExportService.Object,
-            _mockApplicationService.Object,
-            _mockConfigurationService.Object,
-            _mockSearchService.Object)
+            Substitute.For<IOptions<GeneralConfig>>(),
+            _mockHttpContextAccessor,
+            _mockLogger,
+            _mockExportService,
+            _mockApplicationService,
+            _mockConfigurationService,
+            _mockSearchService)
         {
             PageContext = pageContext,
             TempData = tempData,

--- a/modules/end-user/src/gpconnect-appointment-checker.Helpers/Constants/SearchConstants.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker.Helpers/Constants/SearchConstants.cs
@@ -138,6 +138,7 @@
 
         public const string SearchStatsCountText = "{0} free slot{1} found";
         public const string SearchStatsPastCountText = "{0} past slot{1} found";
+        public const string SearchAtDate = "As of {0}";
 
         public const string SearchDetailsButtonText = "Details";
         public const string SearchDetailsLabel = "Details:";

--- a/modules/end-user/src/gpconnect-appointment-checker/Helpers/DefaultTimeZoneProvider.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Helpers/DefaultTimeZoneProvider.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace gpconnect_appointment_checker.Helpers;
+
+public class DefaultTimeZoneProvider : ITimeZoneProvider
+{
+    public TimeZoneInfo FindSystemTimeZoneById(string id)
+    {
+        return TimeZoneInfo.FindSystemTimeZoneById(id);
+    }
+
+    public DateTimeOffset ConvertTime(DateTimeOffset dateTimeOffset, TimeZoneInfo destinationTimeZone)
+    {
+        return TimeZoneInfo.ConvertTime(dateTimeOffset, destinationTimeZone);
+    }
+}

--- a/modules/end-user/src/gpconnect-appointment-checker/Helpers/ITimeZoneProvider.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Helpers/ITimeZoneProvider.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace gpconnect_appointment_checker.Helpers;
+
+public interface ITimeZoneProvider
+{
+    TimeZoneInfo FindSystemTimeZoneById(string id);
+    DateTimeOffset ConvertTime(DateTimeOffset dateTimeOffset, TimeZoneInfo destinationTimeZone);
+}

--- a/modules/end-user/src/gpconnect-appointment-checker/Helpers/SearchPageHelpers.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Helpers/SearchPageHelpers.cs
@@ -1,0 +1,22 @@
+using System;
+using DocumentFormat.OpenXml.EMMA;
+using gpconnect_appointment_checker.Helpers.Constants;
+using gpconnect_appointment_checker.Helpers.Extensions;
+
+namespace gpconnect_appointment_checker.Helpers;
+
+public static class SearchPageHelpers
+{
+    public static string BuildSearchTimeCountString(int count, TimeProvider timeProvider,
+        ITimeZoneProvider timeZoneProvider)
+    {
+        var utcNow = timeProvider.GetUtcNow();
+        var ukTimeZone = timeZoneProvider.FindSystemTimeZoneById("Europe/London");
+        var currentUkTimeOffset = timeZoneProvider.ConvertTime(utcNow, ukTimeZone);
+
+        var formattedUkTime = currentUkTimeOffset.DateTime.ToString("dd MMM HH:mm");
+
+        return
+            $"{string.Format(SearchConstants.SearchAtDate, formattedUkTime)} - {SearchConstants.SearchStatsCountText.Pluraliser(count)}";
+    }
+}

--- a/modules/end-user/src/gpconnect-appointment-checker/Helpers/SearchPageHelpers.cs
+++ b/modules/end-user/src/gpconnect-appointment-checker/Helpers/SearchPageHelpers.cs
@@ -14,7 +14,7 @@ public static class SearchPageHelpers
         var ukTimeZone = timeZoneProvider.FindSystemTimeZoneById("Europe/London");
         var currentUkTimeOffset = timeZoneProvider.ConvertTime(utcNow, ukTimeZone);
 
-        var formattedUkTime = currentUkTimeOffset.DateTime.ToString("dd MMM HH:mm");
+        var formattedUkTime = currentUkTimeOffset.DateTime.ToString("dd MMM yyyy HH:mm");
 
         return
             $"{string.Format(SearchConstants.SearchAtDate, formattedUkTime)} - {SearchConstants.SearchStatsCountText.Pluraliser(count)}";

--- a/modules/end-user/src/gpconnect-appointment-checker/Pages/Private/StatsCount.cshtml
+++ b/modules/end-user/src/gpconnect-appointment-checker/Pages/Private/StatsCount.cshtml
@@ -3,9 +3,20 @@
 
 @if (Model.SearchResultsTotalCount > 0)
 {
+    var ukTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
+    var currentUkTime = TimeZoneInfo.ConvertTime(DateTime.UtcNow, ukTimeZone).ToString("dd MMM yyyy HH:m");
+
+    var message =
+        $"{string.Format(SearchConstants.SearchAtDate, currentUkTime)} - {StringExtensions.Pluraliser(SearchConstants.SearchStatsCountText, Model.SearchResultsCurrentCount)}";
+
+
     <div class="nhsuk-inset-text">
         <span class="nhsuk-u-visually-hidden">Information: </span>
-        @Html.Raw(StringExtensions.Pluraliser(SearchConstants.SearchStatsCountText, Model.SearchResultsCurrentCount, "<div class=\"nhsuk-hint\">", "</div>"))
+        <div class="nhsuk-hint">
+            <p style="font-weight: 700">@message</p>
+            <p>Note: Remember the free slot count can change, as some appointments may be embargoed currently and be released at a later date.</p>
+        </div>
+
         @Html.Raw(StringExtensions.Pluraliser(SearchConstants.SearchStatsPastCountText, Model.SearchResultsPastCount, "<div class=\"nhsuk-hint\">", "</div>"))
     </div>
 }

--- a/modules/end-user/src/gpconnect-appointment-checker/Pages/Private/StatsCount.cshtml
+++ b/modules/end-user/src/gpconnect-appointment-checker/Pages/Private/StatsCount.cshtml
@@ -1,20 +1,15 @@
-﻿@using gpconnect_appointment_checker.Helpers.Constants
+﻿@using gpconnect_appointment_checker.Helpers
+@using gpconnect_appointment_checker.Helpers.Constants
 @using gpconnect_appointment_checker.Helpers.Extensions
 
 @if (Model.SearchResultsTotalCount > 0)
 {
-    var ukTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
-    var currentUkTime = TimeZoneInfo.ConvertTime(DateTime.UtcNow, ukTimeZone).ToString("dd MMM yyyy HH:m");
-
-    var message =
-        $"{string.Format(SearchConstants.SearchAtDate, currentUkTime)} - {StringExtensions.Pluraliser(SearchConstants.SearchStatsCountText, Model.SearchResultsCurrentCount)}";
-
-
     <div class="nhsuk-inset-text">
         <span class="nhsuk-u-visually-hidden">Information: </span>
         <div class="nhsuk-hint">
-            <p style="font-weight: 700">@message</p>
-            <p>Note: Remember the free slot count can change, as some appointments may be embargoed currently and be released at a later date.</p>
+            <p style="font-weight: 700">@SearchPageHelpers.BuildSearchTimeCountString(Model.SearchResultsTotalCount, TimeProvider.System, new DefaultTimeZoneProvider())</p>
+            <p>Note: Remember the free slot count can change throughout the day, as some appointments may be embargoed
+                currently and be released at a later date.</p>
         </div>
 
         @Html.Raw(StringExtensions.Pluraliser(SearchConstants.SearchStatsPastCountText, Model.SearchResultsPastCount, "<div class=\"nhsuk-hint\">", "</div>"))

--- a/modules/end-user/src/gpconnect-appointment-checker/gpconnect-appointment-checker.csproj
+++ b/modules/end-user/src/gpconnect-appointment-checker/gpconnect-appointment-checker.csproj
@@ -28,9 +28,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
     <PackageReference Include="NLog" Version="5.0.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>  
 
   <ItemGroup>


### PR DESCRIPTION
- Add UK date & time to the Search Page, to show when the results were retrieved.

- Add quick note to explain that the appointment count may differ if query at different times in the day due to released appointments / embargoed appointments. 

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/f858ba99-d13f-42cf-9a16-2aae22e978cc" />
